### PR TITLE
[#PCCP-6997]Prevent phpIPAM pool deletion during sync when phpIPAM fails to return subnets

### DIFF
--- a/src/main/groovy/com/morpheusdata/phpipam/PhpIpamProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/phpipam/PhpIpamProvider.groovy
@@ -862,7 +862,11 @@ class PhpIpamProvider implements IPAMProvider {
         requestOptions.ignoreSSL = true
 
         def results = callApi(client,poolServer.serviceUrl, 'subnets', getAppId(poolServer), token, requestOptions, 'GET')
-        rtn.success = results.success
+        log.debug("listNetworks: {}", results)
+        if (results.success && !results.data?.data){ //Known phpIPAM issue — if the number of networks in phpIPAM exceeds a certain threshold, the API may return no data. 
+            log.warn("The API call to phpIPAM returned no results. This may be due to a temporary issue or bug in the external application.")
+        }
+        rtn.success = results.success && (results.data?.data ?: false)
         if(rtn.success) {
             def networkList = results.data.data
             // exclude ipv6 for now


### PR DESCRIPTION
This fix ensures that phpIPAM pools are not deleted during synchronization when subnet data is missing as a result of a known phpIPAM bug.
https://hpe.atlassian.net/browse/PCCP-6997